### PR TITLE
Fix pipex pipeline execution logic

### DIFF
--- a/include/pipex.h
+++ b/include/pipex.h
@@ -31,17 +31,17 @@ typedef struct s_args
 
 t_args	*init_args(char **argv, char **envp);
 void	get_env_path(char **env, t_args *args);
-void	update_cmd_path(t_args *args);
+int	update_cmd_path(t_args *args);
 void	get_cmd_args_list(char **argv, t_args *args);
 void	get_full_paths_binary(t_args *args, int nth_cmd);
 int		check_cmd(char *full_path_binary);
 void	run_cmds(t_args *args, int ntg_cmd);
 
 
-void	free_key_values(t_args *args);
-void	free_paths(t_args *args);
-void	free_cmd_args(t_args *args);
-void	free_full_paths_binary(int i, char **full_paths_binary);
-void	free_everything(t_args *args);
-void	clean_struct(t_args *args);
+void    free_key_values(t_args *args);
+void    free_paths(t_args *args);
+void    free_cmd_args(t_args *args);
+void    free_full_paths_binary(char ***full_paths_binary);
+void    free_everything(t_args *args);
+void    clean_struct(t_args *args);
 #endif

--- a/src/free.c
+++ b/src/free.c
@@ -1,84 +1,58 @@
 #include "../include/pipex.h"
 
-void	free_key_values(t_args *args)
+static void free_string_array(char ***array)
 {
-	int	i;
+    int index;
 
-	i = 0;
-	if (!args->key_values)
-		return ;
-	while (args->key_values[i])
-	{
-		free(args->key_values[i]);
-		args->key_values[i] = NULL;
-		i++;
-	}
-	free(args->key_values);
-	args->key_values = NULL;
+    if (!array || !*array)
+        return ;
+    index = 0;
+    while ((*array)[index])
+    {
+        free((*array)[index]);
+        (*array)[index] = NULL;
+        index++;
+    }
+    free(*array);
+    *array = NULL;
 }
 
-void free_paths(t_args *args)
+void    free_key_values(t_args *args)
 {
-  int i;
-
-  i = 0;
-  if (!args->paths)
-	  return ;
-  while (args->paths[i])
-  {
-    free(args->paths[i]);
-	args->paths[i] = NULL;
-    i++;
-  }
-  free(args->paths);
-  args->paths = NULL;
+    free_string_array(&args->key_values);
 }
 
-void	free_cmd_args(t_args *args)
+void    free_paths(t_args *args)
 {
-	int	i;
-
-	i = 0;
-	if (!args->cmd_args)
-		return ;
-	while (args->cmd_args[i])
-	{
-		free(args->cmd_args[i]);
-		args->cmd_args[i] = NULL;
-		i++;
-	}
-	free(args->cmd_args);
-	args->cmd_args = NULL;
+    free_string_array(&args->paths);
 }
 
-void	free_full_paths_binary(int i, char **full_paths_binary)
+void    free_cmd_args(t_args *args)
 {
-	if (!full_paths_binary)
-		return ;
-	while (i >= 0)
-	{
-		free(full_paths_binary[i]);
-		full_paths_binary[i] = NULL;
-		i--;
-	}
+    free_string_array(&args->cmd1_args);
+    free_string_array(&args->cmd2_args);
 }
 
-void	free_everything(t_args *args)
+void    free_full_paths_binary(char ***full_paths_binary)
 {
-	if (args->key_values)
-		free_key_values(args);
-	if (args->full_paths)
-		free_paths(args);
-	if (args->cmd_args)
-		free_cmd_args(args);
+    free_string_array(full_paths_binary);
 }
 
-void	clean_struct(t_args *args)
+void    free_everything(t_args *args)
 {
-	if (!args->full_paths_binary)
-		return ;
-	free(args->full_paths_binary);
-	if (!args)
-		return ;
-	free(args);
+    if (!args)
+        return ;
+    free_key_values(args);
+    free_paths(args);
+    free_string_array(&args->full_paths);
+    free_cmd_args(args);
+    free_full_paths_binary(&args->full_paths_binary);
+}
+
+void    clean_struct(t_args *args)
+{
+    if (!args)
+        return ;
+    free_everything(args);
+    free(args);
 }

--- a/src/main.c
+++ b/src/main.c
@@ -3,190 +3,304 @@
 #include <stdlib.h>
 #include <unistd.h>
 
-void	get_env_path(char *envp[], t_args *args)
+void    get_env_path(char *envp[], t_args *args)
 {
-  int i;
+    int i;
 
-  i = 0;
-  while (envp[i]) 
-  {
-    if (ft_strncmp("PATH=", envp[i], 5) == 0) 
-	{
-      args->env_path = envp[i];
-	  return ;
-	}
-    i++;
-  }
-  ft_printf("error.\ncannot find the PATH var.\n");
+    i = 0;
+    while (envp[i])
+    {
+        if (ft_strncmp("PATH=", envp[i], 5) == 0)
+        {
+            args->env_path = envp[i];
+            return ;
+        }
+        i++;
+    }
+    ft_putendl_fd("error.", STDERR_FILENO);
+    ft_putendl_fd("cannot find the PATH var.", STDERR_FILENO);
 }
 
-void	update_cmd_path(t_args *args)
+int     update_cmd_path(t_args *args)
 {
-	int		 i;
+    int i;
 
-	args->key_values = ft_split(args->env_path, '=');
-	args->paths = ft_split(args->key_values[1], ':');
-	free_key_values(args);
-	i = 0;
-	while(args->paths[i++]);
-	args->full_paths = (char**)ft_calloc((i), sizeof(char*));
-	i = 0;
-	while (args->paths[i])
-	{
-		args->full_paths[i] = ft_strjoin(args->paths[i], "/");
-		free(args->paths[i]);
-		args->paths[i] = NULL;
-		i++;
-	}
-	free(args->paths);
-	args->paths = NULL;
+    if (!args->env_path)
+        return (-1);
+    args->key_values = ft_split(args->env_path, '=');
+    if (!args->key_values || !args->key_values[1])
+    {
+        free_key_values(args);
+        return (-1);
+    }
+    args->paths = ft_split(args->key_values[1], ':');
+    free_key_values(args);
+    if (!args->paths)
+        return (-1);
+    i = 0;
+    while (args->paths[i])
+        i++;
+    args->full_paths = (char **)ft_calloc(i + 1, sizeof(char *));
+    if (!args->full_paths)
+        return (-1);
+    i = 0;
+    while (args->paths[i])
+    {
+        args->full_paths[i] = ft_strjoin(args->paths[i], "/");
+        if (!args->full_paths[i])
+            return (-1);
+        i++;
+    }
+    free_paths(args);
+    return (0);
 }
 
-void	get_cmd_args_list(char *argv[], t_args *args)
+void    get_cmd_args_list(char *argv[], t_args *args)
 {
-	args->cmd1_args = ft_split(argv[2], ' ');
-	args->cmd2_args = ft_split(argv[3], ' ');
+    args->cmd1_args = ft_split(argv[2], ' ');
+    args->cmd2_args = ft_split(argv[3], ' ');
 }
 
-void	get_full_paths_binary(t_args *args, int nth_cmd)
+void    get_full_paths_binary(t_args *args, int nth_cmd)
 {
-	int		i;
+    int     i;
+    int     count;
+    char    **cmd_args;
 
-	i = 0;
-	while (args->full_paths[i++]);
-	args->full_paths_binary = (char**)ft_calloc((i), sizeof(char*));
-	i = 0;
-	while (args->full_paths[i])
-	{
-		if (nth_cmd == 1)
-			args->full_paths_binary[i] = ft_strjoin(args->full_paths[i], args->cmd1_args[0]);
-		else
-			args->full_paths_binary[i] = ft_strjoin(args->full_paths[i], args->cmd2_args[0]);
-		free(args->full_paths[i]);
-		args->full_paths[i] = NULL;
-		i++;
-	}
-	free(args->full_paths);
-	args->full_paths = NULL;
+    if (!args->full_paths)
+        return ;
+    cmd_args = args->cmd1_args;
+    if (nth_cmd == 2)
+        cmd_args = args->cmd2_args;
+    if (!cmd_args || !cmd_args[0])
+        return ;
+    count = 0;
+    while (args->full_paths[count])
+        count++;
+    args->full_paths_binary = (char **)ft_calloc(count + 1, sizeof(char *));
+    if (!args->full_paths_binary)
+        return ;
+    i = 0;
+    while (i < count)
+    {
+        args->full_paths_binary[i] = ft_strjoin(args->full_paths[i], cmd_args[0]);
+        if (!args->full_paths_binary[i])
+        {
+            free_full_paths_binary(&args->full_paths_binary);
+            break ;
+        }
+        i++;
+    }
+    i = 0;
+    while (args->full_paths[i])
+    {
+        free(args->full_paths[i]);
+        args->full_paths[i] = NULL;
+        i++;
+    }
+    free(args->full_paths);
+    args->full_paths = NULL;
 }
 
-int	check_cmd(char *full_path_binary)
+int     check_cmd(char *full_path_binary)
 {
-	if (access(full_path_binary, F_OK | X_OK) == 0)
-		return (1);
-	// free_path_binary ?
-	return (0);
+    if (access(full_path_binary, F_OK | X_OK) == 0)
+        return (1);
+    return (0);
 }
 
-void	run_cmds(t_args *args, int nth_cmd)
+void    run_cmds(t_args *args, int nth_cmd)
 {
-	int	runnable;
-	int	i;
+    int i;
 
-	i = 0;
-		while (args->full_paths_binary[i])
-		{
-			runnable = check_cmd(args->full_paths_binary[i]);
-			if (!runnable)
-			{
-				free_full_paths_binary(i, args->full_paths_binary);
-			//	free_everything(args);
-			}
-			else if (nth_cmd == 1)
-				execve(args->full_paths_binary[i], args->cmd1_args, args->envp);
-			else
-				execve(args->full_paths_binary[i], args->cmd2_args, args->envp);
-			i++;
-		}
-		if (!runnable)
-		{
-			ft_printf("error. cannot find binary.\n");
-			free_full_paths_binary(i, args->full_paths_binary);
-			free_everything(args);
-		}
+    if (!args->full_paths_binary)
+    {
+        ft_putendl_fd("error. cannot find binary.", STDERR_FILENO);
+        clean_struct(args);
+        exit(127);
+    }
+    i = 0;
+    while (args->full_paths_binary[i])
+    {
+        if (check_cmd(args->full_paths_binary[i]))
+        {
+            if (nth_cmd == 1)
+                execve(args->full_paths_binary[i], args->cmd1_args, args->envp);
+            else
+                execve(args->full_paths_binary[i], args->cmd2_args, args->envp);
+            perror("execve");
+        }
+        i++;
+    }
+    ft_putendl_fd("error. cannot find binary.", STDERR_FILENO);
+    clean_struct(args);
+    exit(127);
 }
 
-t_args	*init_args(char *argv[], char *envp[])
+t_args  *init_args(char *argv[], char *envp[])
 {
-	t_args	*args;
-	args = (t_args *)ft_calloc(1, sizeof(t_args));
-	args->envp = envp;
-	args->argv = argv;
-	get_env_path(envp, args);
-	update_cmd_path(args);
-	get_cmd_args_list(argv, args);
-	args->infile = argv[1];
-	args->outfile = argv[4];
-	return (args);
+    t_args  *args;
+
+    args = (t_args *)ft_calloc(1, sizeof(t_args));
+    if (!args)
+        return (NULL);
+    args->envp = envp;
+    args->argv = argv;
+    get_env_path(envp, args);
+    if (!args->env_path)
+    {
+        clean_struct(args);
+        return (NULL);
+    }
+    if (update_cmd_path(args) == -1)
+    {
+        clean_struct(args);
+        return (NULL);
+    }
+    get_cmd_args_list(argv, args);
+    if (!args->cmd1_args || !args->cmd2_args || !args->cmd1_args[0] || !args->cmd2_args[0])
+    {
+        clean_struct(args);
+        return (NULL);
+    }
+    args->infile = argv[1];
+    args->outfile = argv[4];
+    return (args);
 }
 
-int	redirect_input(t_args *args)
+int     redirect_input(t_args *args)
 {
-	int fd_in;
+    int fd_in;
 
-	fd_in = open(args->infile, O_RDONLY, 0644);
-	if (fd_in == -1)
-		return (ft_printf("error: cannot read infile.\n") & 0);
-	dup2(fd_in, STDIN_FILENO);
-	close(fd_in);
-	return (fd_in);
+    fd_in = open(args->infile, O_RDONLY);
+    if (fd_in == -1)
+    {
+        ft_putendl_fd("error: cannot read infile.", STDERR_FILENO);
+        return (-1);
+    }
+    if (dup2(fd_in, STDIN_FILENO) == -1)
+    {
+        perror("dup2");
+        close(fd_in);
+        return (-1);
+    }
+    close(fd_in);
+    return (0);
 }
 
-int	redirect_output(t_args *args)
+int     redirect_output(t_args *args)
 {
-	int	fd_out;
+    int fd_out;
 
-	fd_out = open(args->outfile, O_WRONLY | O_CREAT | O_TRUNC, 0644);
-	if (fd_out == -1)
-		return (ft_printf("error: cannot read outfile.\n") & 0);
-	dup2(fd_out, STDOUT_FILENO);
-	close(fd_out);
-	return (fd_out);
+    fd_out = open(args->outfile, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    if (fd_out == -1)
+    {
+        ft_putendl_fd("error: cannot read outfile.", STDERR_FILENO);
+        return (-1);
+    }
+    if (dup2(fd_out, STDOUT_FILENO) == -1)
+    {
+        perror("dup2");
+        close(fd_out);
+        return (-1);
+    }
+    close(fd_out);
+    return (0);
+}
+
+static void execute_first_child(t_args *args, int fds[2])
+{
+    close(fds[0]);
+    if (redirect_input(args) == -1)
+    {
+        clean_struct(args);
+        exit(EXIT_FAILURE);
+    }
+    if (dup2(fds[1], STDOUT_FILENO) == -1)
+    {
+        perror("dup2");
+        close(fds[1]);
+        clean_struct(args);
+        exit(EXIT_FAILURE);
+    }
+    close(fds[1]);
+    get_full_paths_binary(args, 1);
+    run_cmds(args, 1);
+}
+
+static void execute_second_child(t_args *args, int fds[2])
+{
+    close(fds[1]);
+    if (dup2(fds[0], STDIN_FILENO) == -1)
+    {
+        perror("dup2");
+        close(fds[0]);
+        clean_struct(args);
+        exit(EXIT_FAILURE);
+    }
+    close(fds[0]);
+    if (redirect_output(args) == -1)
+    {
+        clean_struct(args);
+        exit(EXIT_FAILURE);
+    }
+    get_full_paths_binary(args, 2);
+    run_cmds(args, 2);
 }
 
 int main(int ac, char *argv[], char *envp[])
 {
-	t_args	*args;
-	int		i;
-	int		j;
-	int		fds[2];
-	pid_t	child_one;
-	pid_t	child_two;
-	int		status;
-	pid_t	wpid;
+    t_args  *args;
+    int     fds[2];
+    pid_t   child_one;
+    pid_t   child_two;
+    int     status2;
 
-	if (ac < 5)
-		return (ft_printf("ac is:%d(need exactly 5.)\n", ac) & 0);
-	i = 0;
-	j = 0;
-	args = init_args(argv, envp);
-	pipe(fds);
-	child_one = fork();
-	if (child_one == 0)
-	{
-		close(fds[1]);
-		close(fds[0]);
-		int fd_in = redirect_input(args);	
-		dup2(fd_in, STDOUT_FILENO);
-		close(fd_in);
-		get_full_paths_binary(args, 1);
-		run_cmds(args, 1);
-	}
-	child_two = fork();
-	if (child_two == 0)
-	{
-		//close(fds[0]);
-		close(fds[1]);
-		int fd_out = redirect_output(args);
-		dup2(fd_out, STDIN_FILENO);
-		close(fd_out);
-		get_full_paths_binary(args, 2);
-		run_cmds(args, 2);
-	}
-	wpid = waitpid(child_one, &status, 0);
-	wpid = waitpid(child_two, &status, 0);
-	if (WIFEXITED(status))
-		return (WEXITSTATUS(status));
-	else
-		return (-1);
+    if (ac != 5)
+    {
+        ft_putstr_fd("ac is:", STDERR_FILENO);
+        ft_putnbr_fd(ac, STDERR_FILENO);
+        ft_putendl_fd(" (need exactly 5.)", STDERR_FILENO);
+        return (1);
+    }
+    args = init_args(argv, envp);
+    if (!args)
+        return (1);
+    if (pipe(fds) == -1)
+    {
+        perror("pipe");
+        clean_struct(args);
+        return (1);
+    }
+    child_one = fork();
+    if (child_one == -1)
+    {
+        perror("fork");
+        close(fds[0]);
+        close(fds[1]);
+        clean_struct(args);
+        return (1);
+    }
+    if (child_one == 0)
+        execute_first_child(args, fds);
+    child_two = fork();
+    if (child_two == -1)
+    {
+        perror("fork");
+        close(fds[0]);
+        close(fds[1]);
+        waitpid(child_one, NULL, 0);
+        clean_struct(args);
+        return (1);
+    }
+    if (child_two == 0)
+        execute_second_child(args, fds);
+    close(fds[0]);
+    close(fds[1]);
+    waitpid(child_one, NULL, 0);
+    waitpid(child_two, &status2, 0);
+    clean_struct(args);
+    if (WIFEXITED(status2))
+        return (WEXITSTATUS(status2));
+    return (1);
 }


### PR DESCRIPTION
## Summary
- rebuild command path discovery, process creation, and I/O redirection to execute the pipeline reliably while surfacing errors to stderr
- consolidate cleanup helpers so every allocated argument/path array is released consistently
- adjust the public interface to reflect the new update_cmd_path return value and free helpers

## Testing
- make
- ./pipex infile "cat" "wc -l" outfile
- ./pipex infile "invalidcmd" "wc -l" outfile
- ./pipex missing "cat" "wc -l" outfile

------
https://chatgpt.com/codex/tasks/task_e_68ca1635f6d88330ae5ded259ae5efa3